### PR TITLE
Fix HF tokenizer vocab size calculation.

### DIFF
--- a/megatron/tokenizer/tokenizer.py
+++ b/megatron/tokenizer/tokenizer.py
@@ -307,7 +307,8 @@ class _HFTokenizer:
     
     @property
     def vocab_size(self):
-        return self.tokenizer.vocab_size
+        vocab_size = len(self.tokenizer.get_vocab())
+        return vocab_size
     def tokenize(self, text):
         return self.tokenizer.encode(text)
     def detokenize(self, ids):


### PR DESCRIPTION
The old vocab_size function does not work correctly with special/added tokens. Based on the fork by @rakseli.